### PR TITLE
Make sure the kernel entry point is `_start`

### DIFF
--- a/p2/memmap
+++ b/p2/memmap
@@ -6,7 +6,10 @@ MEMORY
 
 SECTIONS
 {
-    .text : { *(.text*) } > ram
+    .text : { 
+        1_boot.o;
+        *(.text*); 
+    } > ram
     .bss : { *(.bss*) } > ram
 }
 


### PR DESCRIPTION
The old `memmap` didn't explicitly put `1_boot.o` at the beginning of kernel, which made some students' kernel fail to boot